### PR TITLE
Add βTorrent tracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports.announceList = [
   [ 'udp://tracker.openbittorrent.com:80' ],
   [ 'udp://open.demonii.com:1337' ],
   [ 'udp://tracker.webtorrent.io:80' ],
-  [ 'wss://tracker.webtorrent.io' ] // For WebRTC peers (see: WebTorrent.io)
+  [ 'wss://tracker.webtorrent.io' ], // For WebRTC peers (see: WebTorrent.io)
+  [ 'wss://tracker.btorrent.xyz' ]
 ]
 
 module.exports.parseInput = parseInput


### PR DESCRIPTION
To be kept open until Instant.io and βTorrent has been tested enough while having 2 trackers.