### PR TITLE
Added bTorrent's wss tracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports.announceList = [
   [ 'udp://tracker.leechers-paradise.org:6969' ],
   [ 'udp://tracker.coppersurfer.tk:6969' ],
   [ 'udp://exodus.desync.com:6969' ],
-  [ 'wss://tracker.webtorrent.io' ] // For WebRTC peers (see: WebTorrent.io)
+  [ 'wss://tracker.webtorrent.io' ], // For WebRTC peers (see: WebTorrent.io)
+  [ 'wss://tracker.btorrent.xyz' ]
 ]
 
 module.exports.parseInput = parseInput


### PR DESCRIPTION
Seems like torrents have no problems having more than one tracker, can be added completely now.