### PR TITLE
Fix noname input

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function _parseInput (input, opts, cb) {
 
   var commonPrefix = null
   input.forEach(function (item, i) {
-    if (typeof item === 'string') return
+    if (typeof item === 'string' || Buffer.isBuffer(item) && !item.name) return
 
     var path = item.fullPath || item.name
     if (!path) throw new Error('missing required `fullPath` or `name` property on input')
@@ -101,14 +101,14 @@ function _parseInput (input, opts, cb) {
 
   // remove junk files
   input = input.filter(function (item) {
-    if (typeof item === 'string') return true
+    if (typeof item === 'string' || Buffer.isBuffer(item)) return true
     var filename = item.path[item.path.length - 1]
     return notHidden(filename) && junk.not(filename)
   })
 
   if (commonPrefix) {
     input.forEach(function (item) {
-      if (typeof item === 'string') return
+      if (typeof item === 'string' || Buffer.isBuffer(item)) return
       item.path.shift()
     })
   }
@@ -118,7 +118,7 @@ function _parseInput (input, opts, cb) {
   if (!opts.name && typeof input[0] === 'string') opts.name = corePath.basename(input[0])
 
   if (opts.name === undefined) {
-    throw new Error('missing option \'name\' and unable to infer it from input[0].name')
+    opts.name = 'create-torrent:' + Date.now()
   }
 
   var numPaths = input.reduce(function (sum, item) {

--- a/index.js
+++ b/index.js
@@ -137,6 +137,13 @@ function _parseInput (input, opts, cb) {
     opts.name = 'Unnamed Torrent ' + Date.now()
   }
 
+  input.forEach(function (item, index) {
+    var nameless = (Buffer.isBuffer(item) || isReadable(item)) && !item.name
+    if (nameless) {
+      item.name = opts.name + '-' + index
+    }
+  })
+
   var numPaths = input.reduce(function (sum, item) {
     return sum + Number(typeof item === 'string')
   }, 0)

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function _parseInput (input, opts, cb) {
   }
 
   if (opts.name === undefined) {
-    opts.name = 'create-torrent:' + Date.now()
+    opts.name = 'Unnamed Torrent ' + Date.now()
   }
 
   var numPaths = input.reduce(function (sum, item) {

--- a/index.js
+++ b/index.js
@@ -116,8 +116,8 @@ function _parseInput (input, opts, cb) {
     })
   }
 
+  if (!opts.name && commonPrefix) opts.name = commonPrefix
   if (!opts.name) {
-    if (commonPrefix) opts.name = commonPrefix
     // use first found file name
     input.some(function (item) {
       var nameless = (Buffer.isBuffer(item) || isReadable(item)) && !item.name

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function _parseInput (input, opts, cb) {
 
   var commonPrefix = null
   input.forEach(function (item, i) {
-    if (typeof item === 'string' || Buffer.isBuffer(item) && !item.name) return
+    if (typeof item === 'string' || (Buffer.isBuffer(item) && !item.name)) return
 
     var path = item.fullPath || item.name
     if (!path) throw new Error('missing required `fullPath` or `name` property on input')

--- a/index.js
+++ b/index.js
@@ -113,9 +113,22 @@ function _parseInput (input, opts, cb) {
     })
   }
 
-  if (!opts.name && commonPrefix) opts.name = commonPrefix
-  if (!opts.name && input[0] && input[0].name) opts.name = input[0].name
-  if (!opts.name && typeof input[0] === 'string') opts.name = corePath.basename(input[0])
+  if (!opts.name) {
+    if (commonPrefix) opts.name = commonPrefix
+
+    // use first found file name
+    input.some(function (item) {
+      if (Buffer.isBuffer(item) && !item.name) return
+      if (typeof item === 'string') {
+        opts.name = corePath.basename(item)
+        return true
+      }
+      if (item.name) {
+        opts.name = item.name
+        return true
+      }
+    })
+  }
 
   if (opts.name === undefined) {
     opts.name = 'create-torrent:' + Date.now()


### PR DESCRIPTION
Allows to use buffers and streams without the requirement to extend them first with a `name` property. In addition it now iterates over all inputs to use the first matched `name` instead of just checking the `name` of the first input.  