### PR TITLE
Identify when input is already a torrent

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ var stream = require('readable-stream')
  * @return {Buffer} buffer of .torrent file data
  */
 function createTorrent (input, opts, cb) {
+  if (_alreadyIsTorrent(input)) return input
   if (typeof opts === 'function') return createTorrent(input, null, opts)
   opts = opts ? extend(opts) : {}
 
@@ -56,9 +57,27 @@ function createTorrent (input, opts, cb) {
 }
 
 function parseInput (input, opts, cb) {
+  if (_alreadyIsTorrent(input)) return input
   if (typeof opts === 'function') return parseInput(input, null, opts)
   opts = opts ? extend(opts) : {}
   _parseInput(input, opts, cb)
+}
+
+/**
+ * Returns true if input is already a torrent file buffer, false otherwise
+ */
+function _alreadyIsTorrent (input) {
+  if (Buffer.isBuffer(input)) {
+    try {
+      var torrentDict = bencode.decode(input)
+      if (torrentDict.info.name) {
+        return true
+      }
+    } catch (e) {
+      // Errors indicate this is not a torrent file and we'll return false
+    }
+  }
+  return false
 }
 
 /**

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -45,3 +45,18 @@ test('create nested torrent with array of buffers', function (t) {
     t.equals(sha1.sync(parsedTorrent.infoBuffer), '8fa3c08e640db9576156b21f31353402456a0208')
   })
 })
+
+test('identify when the input is already a torrent and just return it', function (t) {
+  t.plan(1)
+
+  var buf1 = new Buffer('buf1')
+  createTorrent(buf1, function (err, torrent1) {
+    t.error(err)
+
+    createTorrent(torrent1, function (err, torrent2) {
+      t.error(err)
+
+      t.equal(0, Buffer.compare(torrent1, torrent2))
+    })
+  })
+})


### PR DESCRIPTION
Don't create a torrent file from something that is already a torrent file.
This makes it so users of WebTorrent can create their own torrent files and seed them without WebTorrent creating a torrent of the torrent file passed in