### PR TITLE
Check fs.stat presence when using path in electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function _parseInput (input, opts, cb) {
 
   // In Electron, use the true file path
   input = input.map(function (item) {
-    if (isBlob(item) && typeof item.path === 'string') return item.path
+    if (isBlob(item) && typeof item.path === 'string' && typeof fs.stat === 'function') return item.path
     return item
   })
 


### PR DESCRIPTION
Some browsers like brave are using electron but not exposing fs functions in the browser.
This checks we will be able to read the file before using the path.