### PR TITLE
Remove WebTorrent's tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ If `announceList` is omitted, the following trackers will be included automatica
 - udp://tracker.leechers-paradise.org:6969
 - udp://tracker.coppersurfer.tk:6969
 - udp://exodus.desync.com:6969
-- wss://tracker.webtorrent.io
 - wss://tracker.btorrent.xyz
 - wss://tracker.openwebtorrent.com
 - wss://tracker.fastcast.nz

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ module.exports.announceList = [
   [ 'udp://tracker.leechers-paradise.org:6969' ],
   [ 'udp://tracker.coppersurfer.tk:6969' ],
   [ 'udp://exodus.desync.com:6969' ],
-  [ 'wss://tracker.webtorrent.io' ],
   [ 'wss://tracker.btorrent.xyz' ],
   [ 'wss://tracker.openwebtorrent.com' ],
   [ 'wss://tracker.fastcast.nz' ]


### PR DESCRIPTION
Now that it has been turned off, we should remove it.