### PR TITLE
Fix/traverse folder on windows share

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,7 @@
 var createTorrent = require('../')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
+var Path = require('path')
 
 test('implicit torrent name and file name', function (t) {
   t.plan(5)
@@ -112,10 +113,10 @@ test('set file names with `name` property', function (t) {
     t.equal(parsedTorrent.files.length, 2)
 
     t.equal(parsedTorrent.files[0].name, 'My Cool File 1')
-    t.equal(parsedTorrent.files[0].path, 'My Cool Torrent/My Cool File 1')
+    t.equal(parsedTorrent.files[0].path, Path.join('My Cool Torrent', 'My Cool File 1'))
 
     t.equal(parsedTorrent.files[1].name, 'My Cool File 2')
-    t.equal(parsedTorrent.files[1].path, 'My Cool Torrent/My Cool File 2')
+    t.equal(parsedTorrent.files[1].path, Path.join('My Cool Torrent', 'My Cool File 2'))
   })
 })
 
@@ -155,10 +156,10 @@ test('set file names with `fullPath` property', function (t) {
     t.equal(parsedTorrent.files.length, 2)
 
     t.equal(parsedTorrent.files[0].name, 'My Cool File 1')
-    t.equal(parsedTorrent.files[0].path, 'My Cool Torrent/My Cool File 1')
+    t.equal(parsedTorrent.files[0].path, Path.join('My Cool Torrent', 'My Cool File 1'))
 
     t.equal(parsedTorrent.files[1].name, 'My Cool File 2')
-    t.equal(parsedTorrent.files[1].path, 'My Cool Torrent/My Cool File 2')
+    t.equal(parsedTorrent.files[1].path, Path.join('My Cool Torrent', 'My Cool File 2'))
   })
 })
 
@@ -198,9 +199,9 @@ test('implicit torrent name from file names with slashes in them', function (t) 
     t.equal(parsedTorrent.files.length, 2)
 
     t.equal(parsedTorrent.files[0].name, 'My Cool File 1')
-    t.equal(parsedTorrent.files[0].path, 'My Cool Folder/My Cool File 1')
+    t.equal(parsedTorrent.files[0].path, Path.join('My Cool Folder', 'My Cool File 1'))
 
     t.equal(parsedTorrent.files[1].name, 'My Cool File 2')
-    t.equal(parsedTorrent.files[1].path, 'My Cool Folder/My Cool File 2')
+    t.equal(parsedTorrent.files[1].path, Path.join('My Cool Folder', 'My Cool File 2'))
   })
 })


### PR DESCRIPTION
Fix for issue #50.

Allow to read from a Windows file share.
Fixed fs.readdir throwing "ENOTSUP" (and not the expected "ENOTDIR") if path argument of traversePath is pointing to a file.
Replaced this mechanism with fs.stat for a more compliant way of determining the file/folder type.

