### PR TITLE
Update piece-length

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "minimist": "^1.1.0",
     "multistream": "^2.0.2",
     "once": "^1.3.0",
-    "piece-length": "^0.0.0",
+    "piece-length": "^1.0.0",
     "readable-stream": "^2.0.5",
     "run-parallel": "^1.0.0",
     "simple-sha1": "^2.0.0",


### PR DESCRIPTION
I’m the author, and 1.0.0 updates the `closest-to` dependency, which is [roughly 7x faster than its previous version](https://github.com/michaelrhodes/closest-to#benchmarks) (edit: it’s actually more like 270x faster when the input is already sorted). That said, I ran a quick test and piece-length@1 is only about 10% faster, but hey, better than nothing?